### PR TITLE
add pip3 install tkinter

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -104,6 +104,8 @@ Vagrant.configure("2") do |config|
     	pip3 install pyexcel
     	pip3 install seaborn
     	pip3 install matplotlib
+	pip3 install python34-tkinter
+	pip3 install tkinter
       echo "installing HTTP server"
     	yum -y install httpd
     	mv /etc/httpd/conf/httpd.conf /etc/httpd/conf/bkup_httpd_conf


### PR DESCRIPTION
Hi, Peter

Python in Centos doesn't come with tkinter package so seaborn and matpotlib can not be imported. So I add two commands in the Vagrantfile. 

After set up your vagrant, if tkinter still haven't installed, please use '$ sudo yum install python34-tkinter' to install it manually. 

Best,
Hardy  